### PR TITLE
Added YugabyteDB in Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The application connects to and generates load on MySQL, PostgreSQL, and MongoDB
 
    - **Postgres**: `user=postgres password='password' dbname=dataset host=postgres port=5432 sslmode=disable`
 
+   - **YugabyteDB**: `user=yugabyte password='password' dbname=dataset host=yugabytedb port=5433 sslmode=disable` (YugabyteDB UI is on port 15433)
+
    - **MongoDB**: `mongodb://databaseAdmin:password@mongodb:27017/`
 
    If you connect to your databases, you probably know the settings to connect, if not, write to us.

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
 
   valkey:
@@ -29,6 +28,23 @@ services:
       - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  yugabytedb:
+    image: "yugabytedb/yugabyte:2024.2.0.0-b145"
+    command: yugabyted start --enable_pg_parity_early_access --tserver_flags="ysql_pg_conf_csv={shared_preload_libraries='pg_stat_monitor'}" --initial_scripts_dir=/docker-entrypoint-initial_scripts_dir --background=false 
+    environment:
+      YSQL_PASSWORD: password
+      YSQL_USER: yugabyte
+    volumes:
+       - ./data/init/postgresql:/docker-entrypoint-initial_scripts_dir
+    ports: 
+      - "5433:5433"
+      - "15433:15433"
+    healthcheck:
+      test: ["CMD-SHELL", "PGPASSWORD=$$YSQL_PASSWORD yugabyted connect ysql <<<''"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docker-compose-full.yaml
+++ b/docker-compose-full.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
 
   valkey:
@@ -69,6 +68,23 @@ services:
       - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  yugabytedb:
+    image: "yugabytedb/yugabyte:2024.2.0.0-b145"
+    command: yugabyted start --enable_pg_parity_early_access --tserver_flags="ysql_pg_conf_csv={shared_preload_libraries='pg_stat_monitor'}" --initial_scripts_dir=/docker-entrypoint-initial_scripts_dir --background=false 
+    environment:
+      YSQL_PASSWORD: password
+      YSQL_USER: yugabyte
+    volumes:
+       - ./data/init/postgresql:/docker-entrypoint-initial_scripts_dir
+    ports: 
+      - "5433:5433"
+      - "15433:15433"
+    healthcheck:
+      test: ["CMD-SHELL", "PGPASSWORD=$$YSQL_PASSWORD yugabyted connect ysql <<<''"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
Hi, I added YugabyteDB in Docker Compose
YugabyteDB is Open Source PostgreSQL-compatible Distributed SQL database, so it just works with the PostgreSQL driver

The YugabyteDB UI can be accessed on port 15433

![image](https://github.com/user-attachments/assets/12f495e4-efd4-48ff-945f-eec8277d69ea)
